### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/grading.yml
+++ b/.github/workflows/grading.yml
@@ -1,4 +1,6 @@
 name: Grading workflow
+permissions:
+  contents: read
 on:
   push:
     paths:


### PR DESCRIPTION
Potential fix for [https://github.com/Trenzalore0/exercise-reference-a-codeql-query/security/code-scanning/4](https://github.com/Trenzalore0/exercise-reference-a-codeql-query/security/code-scanning/4)

To fix the problem, add an explicit `permissions` key to the workflow. You have the option of applying it globally (at the top-level, so it covers all jobs) or individually for each job that needs it. The simplest and most maintainable solution is to add a `permissions` block at the root, after the `name` and before `on` (or just after `on`), with the minimum privileges needed. 

For this workflow, most steps just check out code and call pre-existing actions; unless any of the actions used need to write to issues, pull requests, or repository contents, you can set `permissions` to the minimal:

```yaml
permissions:
  contents: read
```

If an action needs more privileges, increase only as needed. There is little in this grading workflow indicating that additional permissions are necessary.

**Edit**: Add the following just after the `name:` and before `on:` in `.github/workflows/grading.yml`:

```yaml
permissions:
  contents: read
```

No code steps need change; just this new block.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
