### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/link-checker.yml
+++ b/.github/workflows/link-checker.yml
@@ -1,4 +1,6 @@
 name: Check Markdown links
+permissions:
+  contents: read
 
 on: push
 


### PR DESCRIPTION
Potential fix for [https://github.com/Trenzalore0/exercise-reference-a-codeql-query/security/code-scanning/3](https://github.com/Trenzalore0/exercise-reference-a-codeql-query/security/code-scanning/3)

The correct fix is to add a `permissions` block to the workflow. The job only runs link checks and does not need to write to the repository or interact with issues or pull requests, so only `contents: read` is needed. It is best to add `permissions: contents: read` at the workflow root, which applies to all jobs, unless more granular permissions are required for individual jobs (not the case here). The change should be made at the top level of `.github/workflows/link-checker.yml`, just below the `name:` line (and before `on:` if following GitHub's conventions).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
