### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -1,4 +1,6 @@
 name: CI for local local-action
+permissions:
+  contents: read
 on:
   push:
     branches-ignore:


### PR DESCRIPTION
Potential fix for [https://github.com/Trenzalore0/exercise-reference-a-codeql-query/security/code-scanning/1](https://github.com/Trenzalore0/exercise-reference-a-codeql-query/security/code-scanning/1)

To resolve this issue, you should add an explicit `permissions` block to the workflow YAML file. The permissions block can either be placed at the workflow root or within the relevant job(s). Since the workflow only checks out code and runs tests—no writing to repository, PRs, or issue creation is performed—the minimal required permission is read-only access to repository contents.

**How to fix:**
- Add the following block near the top of .github/workflows/CI.yml:
  ```
  permissions:
    contents: read
  ```
- Place this block directly after the workflow name and before the `on:` block, or immediately after `on:` (before `jobs:`).
- No additional external dependencies, imports, or code changes are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
